### PR TITLE
Remove side-effects to fix bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+Version 1.4.2
+    * Many bug fixes
+
 Version 1.0.0
     * Initial release

--- a/figgis/_version.py
+++ b/figgis/_version.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 4, 1)
+__version_info__ = (1, 4, 2)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from figgis import Config, Field, ListField, ValidationError, PropertyError
 
+from copy import deepcopy
 import pytest
 import six
 
@@ -334,3 +335,33 @@ def test_config_extras():
     conf.update(value=2)
     assert conf.copy().value == 2
     assert conf.get('value') == 2
+
+
+def test_nested_validate_missing():
+    def raises_validation_error(value):
+        raise ValidationError('Wrong')
+
+    class Child(Config):
+        field = Field(int, validator=raises_validation_error)
+
+    class Parent(Config):
+        child = Field(Child, required=True)
+
+    Child({})
+    Parent({'child': {}})
+
+
+def test_original_not_modified():
+    data = {
+        'foo': 1,
+        'bar': 'two'
+    }
+    original = deepcopy(data)
+
+    class Conf(Config):
+        foo = Field()
+        baz = Field(key='bar')
+
+    Conf(data)
+
+    assert data == original


### PR DESCRIPTION
Figgis inadvertently modifies the validated/transformed data sometimes.  This replaces such functions with pure functions, removing the side effects.