### PR TITLE
Add nullable keyword argument

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -392,3 +392,32 @@ def test_reserved():
     pytest.raises(TypeError, create_bad_config2)
     pytest.raises(TypeError, create_bad_config3)
     pytest.raises(TypeError, create_bad_config4)
+
+
+def test_nullable():
+    class TestConfig(Config):
+        nullable = Field(nullable=True, required=True)
+        not_nullable = Field(nullable=False, required=True)
+        default = Field(required=True)
+
+    pytest.raises(ValidationError, TestConfig,
+                  nullable=None, not_nullable=None, default=None)
+
+    assert TestConfig(nullable=None, not_nullable='value', default=None)
+    assert TestConfig(nullable='value', not_nullable='value', default='value')
+
+
+def test_nullable_required():
+    class TestConfig(Config):
+        field = Field(nullable=True, required=True)
+
+    pytest.raises(PropertyError, TestConfig)
+
+
+def test_nullable_default():
+    class TestConfig(Config):
+        default = Field(nullable=False, default=None)
+
+    pytest.raises(ValidationError, TestConfig)
+
+    assert TestConfig(default='foo')

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -12,6 +12,7 @@ def test_flat():
         required = Field(int, required=True, help='required')
         choices = Field(int, choices=[1, 2, 3], help='choices')
         list_ = ListField(help='list_')
+        not_nullable = Field(nullable=False)
 
     desc = TestConfig.describe()
     assert desc == """\
@@ -19,6 +20,7 @@ choices (type=int, choices=[1, 2, 3]) - choices
 default (type=int, default=0) - default
 list_ (type=list(str)) - list_
 nodesc (type=str)
+not_nullable (type=str, non-nullable)
 required (type=int, required) - required"""
 
 


### PR DESCRIPTION
Allow fields to be marked (non)nullable.  This fixes a bug in which you couldn't make required fields that had null values.