### PR TITLE
Allow configs to forbid extra values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Version 1.6.1 (2015-05-20)
+--------------------------
+* Add '__allow_extra__' attribute to Configs to disallow extra values being
+  passed in to instances
+
 Version 1.6.0 (2015-04-07)
 --------------------------
 * Add 'to_dict' method to convert configs to plain python data structures

--- a/figgis/_version.py
+++ b/figgis/_version.py
@@ -2,5 +2,5 @@
 # Copyrights licensed under the BSD License. See the accompanying LICENSE
 # file for terms.
 
-__version_info__ = (1, 6, 0)
+__version_info__ = (1, 6, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -421,3 +421,27 @@ def test_nullable_default():
     pytest.raises(ValidationError, TestConfig)
 
     assert TestConfig(default='foo')
+
+
+def test_allow_extra():
+    class TestConfig(Config):
+        __allow_extra__ = False
+
+        foo = Field(int)
+
+    assert TestConfig(foo=1).foo == 1
+    pytest.raises(PropertyError, TestConfig, bar=1)
+
+
+def test_allow_extra_subconfig():
+    class Subconfig(Config):
+        __allow_extra__ = False
+
+        foo = Field(int)
+
+    class TestConfig(Config):
+        __allow_extra__ = True
+
+        sub = Field(Subconfig)
+
+    pytest.raises(PropertyError, TestConfig, sub=dict(bar=1))

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py26,py27,py32,py33,py34
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 
-commands = py.test --ignore=build --ignore=docs --pep8 --flakes --cov={envsitepackagesdir}/figgis -rs -v
+commands = py.test --ignore=build --ignore=docs --pep8 --flakes --cov={envsitepackagesdir}/figgis -rs -v {posargs}
 
 [testenv:coverage]
-commands = py.test --ignore=build --ignore=docs --cov={envsitepackagesdir}/figgis --cov-report=html
+commands = py.test --ignore=build --ignore=docs --cov={envsitepackagesdir}/figgis --cov-report=html {posargs}


### PR DESCRIPTION
Forbid extra values to be sent to `Config` instances.